### PR TITLE
AWS/S3 -> aws/s3

### DIFF
--- a/lib/s3deploy.rb
+++ b/lib/s3deploy.rb
@@ -1,5 +1,5 @@
 require "s3deploy/version"
-require "AWS/S3"
+require "aws/s3"
 require "digest/md5"
 require "yaml"
 


### PR DESCRIPTION
This no longer works without making this lower case.
